### PR TITLE
Integrate Semantic search live cve lookup page

### DIFF
--- a/src/clients/exa_client.py
+++ b/src/clients/exa_client.py
@@ -449,3 +449,13 @@ async def find_similar_threat_articles(
         logger.error(f"Error finding similar articles for '{reference_url}': {str(e)}")
         # Re-raise to trigger retry mechanism
         raise
+
+
+def is_exa_client_available() -> bool:
+    """
+    Checks if the EXA client was successfully initialized.
+
+    Returns:
+        bool: True if the client is initialized and ready, False otherwise.
+    """
+    return exa is not None

--- a/src/dashboard/pages/02_Detailed_Analysis.py
+++ b/src/dashboard/pages/02_Detailed_Analysis.py
@@ -117,8 +117,17 @@ if "patch_tuesday_date" in df.columns:
 # Get a list of CVE IDs for selection
 cve_list = df["cve_id"].tolist()
 
+# Check if a specific CVE was requested via URL parameter
+query_params = st.query_params
+requested_cve = query_params.get("selected_cve")
+
+# Determine the default index for the selectbox
+default_index = 0
+if requested_cve and requested_cve in cve_list:
+    default_index = cve_list.index(requested_cve)
+
 # Right-side selection box
-selected_cve = st.selectbox("Select a vulnerability for detailed analysis:", options=cve_list, index=0)
+selected_cve = st.selectbox("Select a vulnerability for detailed analysis:", options=cve_list, index=default_index)
 
 # Get the selected CVE data
 selected_data = df[df["cve_id"] == selected_cve].iloc[0].to_dict()

--- a/src/utils/database_handler.py
+++ b/src/utils/database_handler.py
@@ -850,7 +850,8 @@ def get_filtered_cves(
             params.append(1 if has_public_exploit else 0)
 
         if keyword:
-            query += " AND description LIKE ?"
+            query += " AND (description LIKE ? OR cve_id LIKE ?)"
+            params.append(f"%{keyword}%")
             params.append(f"%{keyword}%")
 
         # Microsoft-specific filters


### PR DESCRIPTION
Problem: EXA AI results and semantic output fields were not showing up in the Detailed Vulnerability Analysis page.

  Root Cause: The threat intelligence analysis in the Live CVE Lookup page was only displaying results temporarily but not saving them to the threat_articles table in the database.

viper/src/dashboard/pages/03_Live_CVE_Lookup.py to:

  1. Import the save function: Added store_threat_articles to the imports
  2. Save live data results: Added save functionality to the live data threat intelligence section (lines 794-805)
  3. Save local database results: Added save functionality to the local database threat intelligence section (lines 586-597)

  What happens now:

  1. Live CVE Lookup: When you perform threat intelligence analysis on a CVE, the analyzed articles are automatically saved to the database with the cve_id_association field set to the CVE ID.
  2. Detailed Vulnerability Analysis: When you view a CVE in the Detailed Analysis page, the get_articles_for_cve() function will now find the saved threat intelligence articles and display them in the "🌐 External Threat Intelligence Analysis" section.
  3. User feedback: The UI will show success messages like "💾 Saved 3 analyzed articles to database for future reference" when articles are saved.

  Testing:

  To test this:
  1. Go to Live CVE Lookup page
  2. Search for a CVE and perform threat intelligence analysis
  3. Look for the success message about saved articles
  4. Go to Detailed Vulnerability Analysis page
  5. Select the same CVE - you should now see the "🌐 External Threat Intelligence Analysis" section with the EXA AI results and semantic output fields populated!
